### PR TITLE
Update code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ func main() {
 	}
 	// 2. Get server information ===========================================
 	serverInformationResult, _, err := examplesClient.GetServerInformation(
-		&cloudantv1.GetServerInformationOptions{},
+		examplesClient.NewGetServerInformationOptions(),
 	)
 	if err != nil {
 		panic(err)
@@ -220,9 +220,9 @@ func main() {
 	// 3. Get database information for "animaldb" ==========================
 	dbName := "animaldb"
 	databaseInformationResult, _, err := examplesClient.GetDatabaseInformation(
-		&cloudantv1.GetDatabaseInformationOptions{
-			Db: &dbName,
-		},
+		examplesClient.NewGetDatabaseInformationOptions(
+			dbName,
+		),
 	)
 	if err != nil {
 		panic(err)
@@ -233,10 +233,10 @@ func main() {
 		*databaseInformationResult.DocCount)
 	// 5. Get zebra document out of the database by document id ============
 	documentAboutZebraResult, _, err := examplesClient.GetDocument(
-		&cloudantv1.GetDocumentOptions{
-			Db:    &dbName,
-			DocID: core.StringPtr("zebra"),
-		},
+		examplesClient.NewGetDocumentOptions(
+			dbName,
+			"zebra",
+		),
 	)
 	if err != nil {
 		panic(err)
@@ -350,7 +350,7 @@ func main() {
 	// 3.6. Save the document in the database
 	postDocumentOption := client.NewPostDocumentOptions(
 		exampleDbName,
-	).SetDocument(&exampleDocument).SetContentType("application/json")
+	).SetDocument(&exampleDocument)
 
 	postDocumentResult, _, err := client.PostDocument(postDocumentOption)
 	if err != nil {
@@ -439,7 +439,7 @@ func main() {
 		// 2.3. Update the document in the database
 		postDocumentOption := client.NewPostDocumentOptions(
 			exampleDbName,
-		).SetDocument(document).SetContentType("application/json")
+		).SetDocument(document)
 
 		postDocumentResult, _, err := client.PostDocument(
 			postDocumentOption,
@@ -504,10 +504,10 @@ func main() {
 
 	// 2.1. Get the document if it previously existed in the database
 	document, getDocumentResponse, err := client.GetDocument(
-		&cloudantv1.GetDocumentOptions{
-			Db:    &exampleDbName,
-			DocID: &exampleDocID,
-		},
+		client.NewGetDocumentOptions(
+			exampleDbName,
+			exampleDocID,
+		),
 	)
 	if err != nil {
 		if getDocumentResponse.StatusCode == 404 {

--- a/examples/src/create_db_and_doc/create_db_and_doc.go
+++ b/examples/src/create_db_and_doc/create_db_and_doc.go
@@ -89,7 +89,7 @@ func main() {
 	// 3.6. Save the document in the database
 	postDocumentOption := client.NewPostDocumentOptions(
 		exampleDbName,
-	).SetDocument(&exampleDocument).SetContentType("application/json")
+	).SetDocument(&exampleDocument)
 
 	postDocumentResult, _, err := client.PostDocument(postDocumentOption)
 	if err != nil {

--- a/examples/src/delete_doc/delete_doc.go
+++ b/examples/src/delete_doc/delete_doc.go
@@ -36,10 +36,10 @@ func main() {
 
 	// 2.1. Get the document if it previously existed in the database
 	document, getDocumentResponse, err := client.GetDocument(
-		&cloudantv1.GetDocumentOptions{
-			Db:    &exampleDbName,
-			DocID: &exampleDocID,
-		},
+		client.NewGetDocumentOptions(
+			exampleDbName,
+			exampleDocID,
+		),
 	)
 	if err != nil {
 		if getDocumentResponse.StatusCode == 404 {

--- a/examples/src/get_info_from_existing_database/get_info_from_existing_database.go
+++ b/examples/src/get_info_from_existing_database/get_info_from_existing_database.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/IBM/go-sdk-core/v4/core"
 	"github.com/IBM/cloudant-go-sdk/cloudantv1"
 )
 
@@ -34,7 +33,7 @@ func main() {
 	}
 	// 2. Get server information ===========================================
 	serverInformationResult, _, err := examplesClient.GetServerInformation(
-		&cloudantv1.GetServerInformationOptions{},
+		examplesClient.NewGetServerInformationOptions(),
 	)
 	if err != nil {
 		panic(err)
@@ -43,9 +42,9 @@ func main() {
 	// 3. Get database information for "animaldb" ==========================
 	dbName := "animaldb"
 	databaseInformationResult, _, err := examplesClient.GetDatabaseInformation(
-		&cloudantv1.GetDatabaseInformationOptions{
-			Db: &dbName,
-		},
+		examplesClient.NewGetDatabaseInformationOptions(
+			dbName,
+		),
 	)
 	if err != nil {
 		panic(err)
@@ -56,10 +55,10 @@ func main() {
 		*databaseInformationResult.DocCount)
 	// 5. Get zebra document out of the database by document id ============
 	documentAboutZebraResult, _, err := examplesClient.GetDocument(
-		&cloudantv1.GetDocumentOptions{
-			Db:    &dbName,
-			DocID: core.StringPtr("zebra"),
-		},
+		examplesClient.NewGetDocumentOptions(
+			dbName,
+			"zebra",
+		),
 	)
 	if err != nil {
 		panic(err)

--- a/examples/src/update_doc/update_doc.go
+++ b/examples/src/update_doc/update_doc.go
@@ -62,7 +62,7 @@ func main() {
 		// 2.3. Update the document in the database
 		postDocumentOption := client.NewPostDocumentOptions(
 			exampleDbName,
-		).SetDocument(document).SetContentType("application/json")
+		).SetDocument(document)
 
 		postDocumentResult, _, err := client.PostDocument(
 			postDocumentOption,


### PR DESCRIPTION
## PR summary

- Update struct literals to initializers
- Remove `SetContentType` from code examples as content-type now
  explicitly set by `PostDocument` operaton when Document body is present

Fixes: #6 

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Readme recommends explicit setter for content-type on a doc update

## What is the new behavior?
Remove the explicit setter

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

For the reference, automatic set of content-type on [`client.PostDocument`](https://github.com/IBM/cloudant-go-sdk/blob/master/cloudantv1/cloudant_v1.go#L961)
