### PR TITLE
Revert "ci: temporarily remove race detection from travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.28.2
 
 script:
-- go test ./... -coverprofile=coverage.txt -covermode=set
+- go test ./... -race -coverprofile=coverage.txt -covermode=atomic
 - golangci-lint run
 
 after_sucess:


### PR DESCRIPTION
Reverts IBM/cloudant-go-sdk#58

Draft pending upstream fix of generated test code.