### PR TITLE
Fix race in async session refresh and make getCookie a thread-safe operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor/
 *.env
 
 package-lock.json
+junitreports

--- a/auth/couchdb_session_authenticator_test.go
+++ b/auth/couchdb_session_authenticator_test.go
@@ -284,6 +284,75 @@ var _ = Describe("Authenticator Unit Tests", func() {
 
 		err = auth.Authenticate(request)
 		Expect(err).To(HaveOccurred())
-		Expect(string(authError)).To(Equal(err.Error()))
+		Expect(err.Error()).To(Equal(string(authError)))
+	})
+
+	It("Test missing AuthSession cookie in the response", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		builder, err := core.NewRequestBuilder(core.GET).
+			ResolveRequestURL(server.URL, "/db", nil)
+		Expect(err).To(BeNil())
+
+		request, err := builder.Build()
+		Expect(err).To(BeNil())
+		Expect(request).ToNot(BeNil())
+
+		auth, err := NewCouchDbSessionAuthenticator("user", "pass")
+		Expect(err).To(BeNil())
+		Expect(auth).ToNot(BeNil())
+		Expect(auth.AuthenticationType()).To(Equal(AUTHTYPE_COUCHDB_SESSION))
+
+		err = auth.Authenticate(request)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(HavePrefix("Missing AuthSession cookie"))
+	})
+
+	It("Test invalid format for AuthSession", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cookie := &http.Cookie{
+				Name: "AuthSession",
+				// "fake:fake" in base64
+				Value: "ZmFrZTpmYWtlCg==",
+			}
+			http.SetCookie(w, cookie)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		builder, err := core.NewRequestBuilder(core.GET).
+			ResolveRequestURL(server.URL, "/db", nil)
+		Expect(err).To(BeNil())
+
+		request, err := builder.Build()
+		Expect(err).To(BeNil())
+		Expect(request).ToNot(BeNil())
+
+		auth, err := NewCouchDbSessionAuthenticator("user", "pass")
+		Expect(err).To(BeNil())
+		Expect(auth).ToNot(BeNil())
+		Expect(auth.AuthenticationType()).To(Equal(AUTHTYPE_COUCHDB_SESSION))
+
+		err = auth.Authenticate(request)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(HavePrefix("Invalid format for AuthSession"))
+	})
+
+	It("Test requestSession fails when auth URL is invalid", func() {
+		auth := &CouchDbSessionAuthenticator{}
+		_, err := auth.requestSession()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("service URL is empty"))
+	})
+
+	It("Test requestSession fails when server's down", func() {
+		auth := &CouchDbSessionAuthenticator{}
+		auth.url = "http://localhost"
+		_, err := auth.requestSession()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).Should(HaveSuffix("connection refused"))
 	})
 })

--- a/auth/session.go
+++ b/auth/session.go
@@ -26,13 +26,12 @@ import (
 	"time"
 )
 
-var refreshMutex sync.Mutex
-
 // session represent CouchDB AuthSession token and its expiration period.
 type session struct {
-	cookie      *http.Cookie
-	expires     time.Time
-	refreshTime time.Time
+	cookie       *http.Cookie
+	expires      time.Time
+	refreshTime  time.Time
+	refreshMutex sync.Mutex
 }
 
 // newSession returns new session object constructed from AuthSession cookie.
@@ -75,8 +74,8 @@ func (s *session) isValid() bool {
 func (s *session) needsRefresh() bool {
 	now := time.Now()
 	if now.After(s.refreshTime) {
-		refreshMutex.Lock()
-		defer refreshMutex.Unlock()
+		s.refreshMutex.Lock()
+		defer s.refreshMutex.Unlock()
 
 		// advance refresh time by one minute to prevent a parallel process
 		// that might be waiting on mutex right now


### PR DESCRIPTION
## PR summary

### The issues

This PR fixes three issues

#### Locality of session's and authenticator's refresh mutexes

The auth package's using two mutexes: one on `syncRequestSession` operation of authenticator module and another on modification of `refreshTime` in session. Since it's totally possible to have more then one authenticator (and consequently more than one session) instance in an app, the mutexes need to be local to the instances, otherwise they might introduce intermittent global blocking across all the service instances.

#### Not thread-safe usage of `session` var in `CouchDbSessionAuthenticator`

This is detected as a race by the tests, but only because we are testing `syncRequestSession` concurrently. In reality it's more of an issue with `CouchDbSessionAuthenticator` not to be thread-safe, because it's possible to do reading of `session` in `getCookie` in one thread while updating it during `requestSession` call in the other.

While we are controlling an atomicity of `syncRequestSession` _operation_, we are not insuring atomicity `session` variable's  read/write, so the race detector triggered on this.

#### Race in async session refresh

This one needs a bit of explanation. The race triggered by the fact that we are spawing a goroutine to run `requestSession` and update `session` while still reading `session` on main thread. While technically this is a race we are controlling it by manipulating refresh time in `session` instance, so this is again the case where we are insuring an atomicity of an operation, but not a variable. In other words this is not a real race, but race detector can't tell that, since all the locking logic is happening in code.

### Changes

Fix for `syncRequestSession` not thread-safeness is pretty straight forward - I've added a read-write mutex on `getCookie` operation (and removed now unnecessary `requestSessionMutex`), so `session` read and update became atomic. This will add a performance penalty of course, so if this will become an issue we can either remove mutex and explicitly say that our service instances are not thread-safe or refactor code to use atomic variable for `session` and mutex only on write. I tried to do this already, but it produced a noticeably more complex code, so I'd like to confirm that current simpler solution is been an issue first - the mutex overhead might be negligible comparing to HTTP requests operations. 

The fix for async session refresh is a bit more subtle. We want to keep this refresh operation unblocking, so we can't just add a lock to it. I've added a buffered channel of size one for `*session` on `CouchDbSessionAuthenticator`, so now when refresh finished, instead of updating session on `auth` instance directly, it is passing fresh `session` to the channel and then auth instance flush this channel on every `getCookie` call and update `session` if finds a fresh instance in there.

### Testing

Since we removed race detector from CI, the proper test is to pull this request and run it with `go vet ./auth/...` and ` go test -v -race ./auth/...`

Fixes: #72

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
The authenticator's test trigger race detection failure.

## What is the new behavior?
The authenticator's test are passing

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
