### PR TITLE
Explicitly set content-type in couch auth request and fix tests deprecation warnings

### DIFF
--- a/auth/couchdb_session_authenticator.go
+++ b/auth/couchdb_session_authenticator.go
@@ -208,7 +208,7 @@ func (a *CouchDbSessionAuthenticator) requestSession() (*session, error) {
 		return nil, err
 	}
 
-	builder.AddHeader(core.CONTENT_TYPE, core.DEFAULT_CONTENT_TYPE).
+	builder.AddHeader(core.CONTENT_TYPE, "application/x-www-form-urlencoded").
 		AddFormData("name", "", "", a.Username).
 		AddFormData("password", "", "", a.Password).
 		WithContext(a.ctx)

--- a/auth/couchdb_session_authenticator_test.go
+++ b/auth/couchdb_session_authenticator_test.go
@@ -170,100 +170,109 @@ var _ = Describe("Authenticator Unit Tests", func() {
 			Expect(auth.Client.Timeout).To(Equal(time.Second))
 		})
 
-		It("Test authentication re-request after expiration", func(done Done) {
-			err = auth.Authenticate(request)
-			Expect(err).To(BeNil())
+		It("Test authentication re-request after expiration", func() {
+			testDone := make(chan interface{})
+			go func() {
 
-			// Fetch a cookie from the cache to confirm it's present
-			// and prepare cache state for the next test
-			cookie, err := auth.getCookie()
-			Expect(err).To(BeNil())
-			Expect(cookie).ToNot(BeNil())
-			Expect(cookie.Name).To(Equal("AuthSession"))
-			Expect(cookie.Value).To(Equal("fakefake-1"))
-			Expect(cookie.Expires).ToNot(BeNil())
+				err = auth.Authenticate(request)
+				Expect(err).To(BeNil())
 
-			// Fetch cookie again to verify cache is working as expected,
-			// we are getting old cookie and refresh process's not triggered
-			oldRefresh := auth.session.refreshTime
-			cookie, err = auth.getCookie()
-			Expect(err).To(BeNil())
-			Expect(cookie.Value).To(Equal("fakefake-1"))
-			Expect(auth.session.refreshTime).To(Equal(oldRefresh))
+				// Fetch a cookie from the cache to confirm it's present
+				// and prepare cache state for the next test
+				cookie, err := auth.getCookie()
+				Expect(err).To(BeNil())
+				Expect(cookie).ToNot(BeNil())
+				Expect(cookie.Name).To(Equal("AuthSession"))
+				Expect(cookie.Value).To(Equal("fakefake-1"))
+				Expect(cookie.Expires).ToNot(BeNil())
 
-			// Force expiration and verify we got a new cookie
-			auth.session.expires = time.Now().Add(-time.Minute)
+				// Fetch cookie again to verify cache is working as expected,
+				// we are getting old cookie and refresh process's not triggered
+				oldRefresh := auth.session.refreshTime
+				cookie, err = auth.getCookie()
+				Expect(err).To(BeNil())
+				Expect(cookie.Value).To(Equal("fakefake-1"))
+				Expect(auth.session.refreshTime).To(Equal(oldRefresh))
 
-			// Run getCookie in three parallel threads, to verify
-			// that request mutex works and we are querying /_session only once
-			var wg sync.WaitGroup
+				// Force expiration and verify we got a new cookie
+				auth.session.expires = time.Now().Add(-time.Minute)
 
-			for i := 1; i <= 3; i++ {
-				wg.Add(1)
-				go func() {
-					defer GinkgoRecover()
-					defer wg.Done()
-					cookie, err := auth.getCookie()
-					Expect(err).To(BeNil())
-					Expect(cookie.Value).To(Equal("fakefake-2"))
-					Expect(auth.session.refreshTime).ToNot(Equal(oldRefresh))
-				}()
-			}
-			wg.Wait()
-			close(done)
+				// Run getCookie in three parallel threads, to verify
+				// that request mutex works and we are querying /_session only once
+				var wg sync.WaitGroup
+
+				for i := 1; i <= 3; i++ {
+					wg.Add(1)
+					go func() {
+						defer GinkgoRecover()
+						defer wg.Done()
+						cookie, err := auth.getCookie()
+						Expect(err).To(BeNil())
+						Expect(cookie.Value).To(Equal("fakefake-2"))
+						Expect(auth.session.refreshTime).ToNot(Equal(oldRefresh))
+					}()
+				}
+				wg.Wait()
+				close(testDone)
+			}()
+			Eventually(testDone, 1.0).Should(BeClosed())
 		})
 
-		It("Test authentication refresh", func(done Done) {
-			err = auth.Authenticate(request)
-			Expect(err).To(BeNil())
+		It("Test authentication refresh", func() {
+			testDone := make(chan interface{})
+			go func() {
+				err = auth.Authenticate(request)
+				Expect(err).To(BeNil())
 
-			// Test code path in getCookie() when needsRefresh() is false
-			oldCookie, err := auth.getCookie()
-			Expect(err).To(BeNil())
-			Expect(oldCookie).ToNot(BeNil())
-			Expect(oldCookie.Value).To(Equal("fakefake-1"))
+				// Test code path in getCookie() when needsRefresh() is false
+				oldCookie, err := auth.getCookie()
+				Expect(err).To(BeNil())
+				Expect(oldCookie).ToNot(BeNil())
+				Expect(oldCookie.Value).To(Equal("fakefake-1"))
 
-			// Move time into the refresh window
-			auth.session.refreshTime = time.Now().Add(-10 * time.Minute)
+				// Move time into the refresh window
+				auth.session.refreshTime = time.Now().Add(-10 * time.Minute)
 
-			// Run getCookie in three parallel threads, to verify
-			// that we are still serving stale cached cookie
-			// and request mutex works and we are querying /_session only once
-			var refresherNumber int32
-			var wg sync.WaitGroup
+				// Run getCookie in three parallel threads, to verify
+				// that we are still serving stale cached cookie
+				// and request mutex works and we are querying /_session only once
+				var refresherNumber int32
+				var wg sync.WaitGroup
 
-			for i := 1; i <= 3; i++ {
-				wg.Add(1)
-				go func() {
-					defer GinkgoRecover()
-					defer wg.Done()
-					atomic.AddInt32(&refresherNumber, 1)
-					cookie, err := auth.getCookie()
-					// make sure that at least first refresh is async
-					// and returns an old still-valid cookie
-					if int(atomic.LoadInt32(&refresherNumber)) == 1 {
-						Expect(err).To(BeNil())
-						Expect(cookie).To(Equal(oldCookie))
-						Expect(cookie.Value).To(Equal("fakefake-1"))
-					}
-				}()
-			}
-			wg.Wait()
+				for i := 1; i <= 3; i++ {
+					wg.Add(1)
+					go func() {
+						defer GinkgoRecover()
+						defer wg.Done()
+						atomic.AddInt32(&refresherNumber, 1)
+						cookie, err := auth.getCookie()
+						// make sure that at least first refresh is async
+						// and returns an old still-valid cookie
+						if int(atomic.LoadInt32(&refresherNumber)) == 1 {
+							Expect(err).To(BeNil())
+							Expect(cookie).To(Equal(oldCookie))
+							Expect(cookie.Value).To(Equal("fakefake-1"))
+						}
+					}()
+				}
+				wg.Wait()
 
-			// wait for 1s (default duration) to confirm that eventually
-			// we'll get a new cookie.
-			Eventually(func() (*http.Cookie, error) {
-				return auth.getCookie()
-			}).ShouldNot(Equal(oldCookie))
+				// wait for 1s (default duration) to confirm that eventually
+				// we'll get a new cookie.
+				Eventually(func() (*http.Cookie, error) {
+					return auth.getCookie()
+				}).ShouldNot(Equal(oldCookie))
 
-			// wait a bit to confirm that we haven't had hits
-			// from some late refresh process
-			Consistently(func() int {
-				return int(atomic.LoadInt32(&callNumber))
-			}, "100ms", "100ms").Should(Equal(2))
+				// wait a bit to confirm that we haven't had hits
+				// from some late refresh process
+				Consistently(func() int {
+					return int(atomic.LoadInt32(&callNumber))
+				}, "100ms", "100ms").Should(Equal(2))
 
-			close(done)
-		}, 3.0)
+				close(testDone)
+			}()
+			Eventually(testDone, 3.0).Should(BeClosed())
+		})
 	})
 
 	It("Test authentication failures", func() {


### PR DESCRIPTION
## PR summary

In `go-sdk-core` v5.6.0 constant `DEFAULT_CONTENT_TYPE` was removed breaking our couch auth module.

This PR sets content-type in auth request explicitly to fix that.

Also ginkgo 2.0 introducing new breaking changes removing async tests and the tests were throwing a deprecation warnings, so the tests were updated according to [migration guide](https://github.com/onsi/ginkgo/blob/v2/docs/MIGRATING_TO_V2.md#removed-async-testing) to remediate that.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
