### PR TITLE
Set default client timeout to 6 minutes

### DIFF
--- a/common/cloudant_base.go
+++ b/common/cloudant_base.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	neturl "net/url"
 	"strings"
+	"time"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 )
@@ -93,6 +94,9 @@ func NewBaseService(opts *core.ServiceOptions) (*BaseService, error) {
 	if err != nil {
 		return &BaseService{}, err
 	}
+	client := core.DefaultHTTPClient()
+	client.Timeout = 6 * time.Minute
+	baseService.SetHTTPClient(client)
 	return &BaseService{0, baseService}, nil
 }
 


### PR DESCRIPTION
## PR summary

This change adds a default 6 minutes timeout on sdk's client.

Note that this is a complete request's duration timeout from connect to end of response based on deadline, i.e. it is not reset when server side is responding, hence it is adds a hard cap on duration of `longpoll` request to changes feed.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Request stays indefinitely when server side hangs.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Requests interrupted after 6 minutes of continuous run with `use of closed network connection (Client.Timeout or context cancellation while reading body)` message

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
