### PR TITLE
Set proper expiration time on auth session cookie if missing

### DIFF
--- a/auth/session.go
+++ b/auth/session.go
@@ -22,6 +22,9 @@ import (
 	"time"
 )
 
+// endOfTime is the time when session (non-persistent) cookies expire.
+var endOfTime = time.Now().AddDate(0, 0, 14)
+
 // session represent CouchDB AuthSession token and its expiration period.
 type session struct {
 	cookie       *http.Cookie
@@ -34,8 +37,7 @@ type session struct {
 func newSession(c *http.Cookie) (*session, error) {
 	expires := c.Expires
 	if expires.IsZero() {
-		// RFC6265 - Set the cookie's expiry-time to the latest representable date.
-		expires = time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+		expires = endOfTime
 	}
 
 	// refreshTime is 20% of period between now and the expiration time

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -56,8 +56,7 @@ var _ = Describe("Session Unit Tests", func() {
 		Expect(s).ToNot(BeNil())
 		Expect(s.getCookie()).To(Equal(cookie))
 		Expect(s.expires).ToNot(BeZero())
-		// non-persistent cookie expiration set to end of time, can't add time to it
-		Expect(s.refreshTime).To(BeTemporally("==", s.expires))
+		Expect(s.refreshTime).To(BeTemporally("<", s.expires))
 		Expect(s.isValid()).To(BeTrue())
 	})
 


### PR DESCRIPTION
## PR summary

CouchDB can be configured to return a session cookie without an expiration time. Previously we made an attempt to parse returned auth token to identify the expiration time. Turned out the time in the auth token set not to an expiration time, but to an issue time, leading for the session authenticator to re-request the session cookie on each new request.

To remediate this the session authenticator now sets expiration time on an acquired cookie with missing expiration to the end of time (Dec 31 9999) as specified in RFC6265. This leads for such cookie to never expire and provides behavior parity with the rest of SDKs. 

<!-- please include a brief summary of the changes in this PR -->

Closes: #196 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-go-sdk/blob/master/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When persistent auth cookie is not set on a server side, couch session authenticator pulls a new session cookie on every request. 

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

When persistent auth cookie is not set on a server side, couch session authenticator never refreshes cookie until server side rejects it at which moment the authenticator does sync request for a new cookie. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
