### PR TITLE
Move func GetAuthenticatorFromEnvironment into common module

### DIFF
--- a/auth/couchdb_session_authenticator.go
+++ b/auth/couchdb_session_authenticator.go
@@ -45,7 +45,7 @@ type CouchDbSessionAuthenticator struct {
 	Client *http.Client
 
 	// CouchDB URL inherited from the service config.
-	url string
+	URL string
 
 	// Client's headers inherited from the service request.
 	header http.Header
@@ -54,7 +54,7 @@ type CouchDbSessionAuthenticator struct {
 	ctx context.Context
 
 	// A flag that indicates whether verification of the server's SSL certificate should be disabled; INherired from the service config
-	disableSSLVerification bool
+	DisableSSLVerification bool
 
 	// A session instance that stores and manages the authentication cookie.
 	session *session
@@ -100,12 +100,12 @@ func GetAuthenticatorFromEnvironment(credentialKey string) (core.Authenticator, 
 	if ok && strings.EqualFold(authType, AUTHTYPE_COUCHDB_SESSION) {
 		authenticator, err := NewCouchDbSessionAuthenticatorFromMap(props)
 		if url, ok := props[core.PROPNAME_SVC_URL]; ok && url != "" {
-			authenticator.url = url
+			authenticator.URL = url
 		}
 		if disableSSLVerification, ok := props[core.PROPNAME_SVC_DISABLE_SSL]; ok && disableSSLVerification != "" {
 			boolValue, err := strconv.ParseBool(disableSSLVerification)
 			if err == nil && boolValue {
-				authenticator.disableSSLVerification = true
+				authenticator.DisableSSLVerification = true
 			}
 		}
 		return authenticator, err
@@ -144,7 +144,7 @@ func (a *CouchDbSessionAuthenticator) Validate() error {
 // Authenticate adds session authentication cookie to a request.
 func (a *CouchDbSessionAuthenticator) Authenticate(request *http.Request) error {
 
-	a.url = request.URL.Scheme + "://" + request.URL.Host
+	a.URL = request.URL.Scheme + "://" + request.URL.Host
 	a.header = request.Header
 	a.ctx = request.Context()
 
@@ -203,7 +203,7 @@ func (a *CouchDbSessionAuthenticator) flushRefreshChannel() {
 // requestSession fetches new AuthSession cookie from the server.
 func (a *CouchDbSessionAuthenticator) requestSession() (*session, error) {
 	builder, err := core.NewRequestBuilder(core.POST).
-		ResolveRequestURL(a.url, "/_session", nil)
+		ResolveRequestURL(a.URL, "/_session", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (a *CouchDbSessionAuthenticator) requestSession() (*session, error) {
 		a.Client = &http.Client{
 			Timeout: time.Second * 30,
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: a.disableSSLVerification},
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: a.DisableSSLVerification},
 			},
 		}
 	}

--- a/auth/couchdb_session_authenticator_test.go
+++ b/auth/couchdb_session_authenticator_test.go
@@ -48,8 +48,8 @@ var _ = Describe("Authenticator Unit Tests", func() {
 
 		sessionAuth, ok := auth.(*CouchDbSessionAuthenticator)
 		Expect(ok).To(BeTrue())
-		Expect(sessionAuth.url).ToNot(BeZero())
-		Expect(sessionAuth.disableSSLVerification).To(BeFalse())
+		Expect(sessionAuth.URL).ToNot(BeZero())
+		Expect(sessionAuth.DisableSSLVerification).To(BeFalse())
 
 		auth, err = GetAuthenticatorFromEnvironment("service2")
 		Expect(err).To(BeNil())
@@ -58,8 +58,8 @@ var _ = Describe("Authenticator Unit Tests", func() {
 
 		sessionAuth, ok = auth.(*CouchDbSessionAuthenticator)
 		Expect(ok).To(BeTrue())
-		Expect(sessionAuth.url).ToNot(BeZero())
-		Expect(sessionAuth.disableSSLVerification).To(BeTrue())
+		Expect(sessionAuth.URL).ToNot(BeZero())
+		Expect(sessionAuth.DisableSSLVerification).To(BeTrue())
 
 		auth, err = GetAuthenticatorFromEnvironment("service3")
 		Expect(err).To(BeNil())
@@ -155,7 +155,7 @@ var _ = Describe("Authenticator Unit Tests", func() {
 			err = auth.Authenticate(request)
 			Expect(err).To(BeNil())
 
-			Expect(auth.url).To(Equal(server.URL))
+			Expect(auth.URL).To(Equal(server.URL))
 			Expect(auth.header).To(HaveKeyWithValue("X-Req-Id", []string{"abcdefgh"}))
 			Expect(auth.ctx.Value(contextKey("key"))).To(Equal("abcdefgh"))
 		})
@@ -340,7 +340,7 @@ var _ = Describe("Authenticator Unit Tests", func() {
 
 	It("Test requestSession fails when server's down", func() {
 		auth := &CouchDbSessionAuthenticator{}
-		auth.url = "http://localhost"
+		auth.URL = "http://localhost"
 		_, err := auth.requestSession()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).Should(HaveSuffix("connection refused"))


### PR DESCRIPTION
## PR summary

First of two PR's to move `GetAuthenticatorFromEnvironment` function into `common` module for better coherency.

<!-- please include a brief summary of the changes in this PR -->

Fixes: #187 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-go-sdk/blob/master/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Function `GetAuthenticatorFromEnvironment` is in `auth` module.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Function `GetAuthenticatorFromEnvironment` verbatim copied into `common` module.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

This is [3 parts change](https://github.com/IBM/cloudant-go-sdk/issues/187#issuecomment-941087731), so follow-up removal of `GetAuthenticatorFromEnvironment` coming in later.

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
