### PR TITLE
Validate trailing slash stripped on request build

### DIFF
--- a/common/cloudant_base_test.go
+++ b/common/cloudant_base_test.go
@@ -177,7 +177,7 @@ var _ = Describe(`Cloudant custom base service UT`, func() {
 		Expect(err).To(BeNil())
 
 		builder := core.NewRequestBuilder(core.GET)
-		_, err = builder.ResolveRequestURL(cloudant.Options.URL, "/db", map[string]string{})
+		_, err = builder.ResolveRequestURL(cloudant.Options.URL, "/db", nil)
 		Expect(err).To(BeNil())
 		Expect(builder.URL.String()).To(Equal("https://cloudant.example/db"))
 	})

--- a/common/cloudant_base_test.go
+++ b/common/cloudant_base_test.go
@@ -167,4 +167,18 @@ var _ = Describe(`Cloudant custom base service UT`, func() {
 		Expect(authenticator).ToNot(BeNil())
 		Expect(authenticator.AuthenticationType()).To(Equal(core.AUTHTYPE_IAM))
 	})
+
+	It("Validates URL trailing slash is stripped", func() {
+		cloudant, err := NewBaseService(&core.ServiceOptions{
+			URL:           "https://cloudant.example/",
+			Authenticator: &core.NoAuthAuthenticator{},
+		})
+		Expect(cloudant).ToNot(BeNil())
+		Expect(err).To(BeNil())
+
+		builder := core.NewRequestBuilder(core.GET)
+		_, err = builder.ResolveRequestURL(cloudant.Options.URL, "/db", map[string]string{})
+		Expect(err).To(BeNil())
+		Expect(builder.URL.String()).To(Equal("https://cloudant.example/db"))
+	})
 })


### PR DESCRIPTION
## PR summary

Add a test to validate that we are stripping a trailing slash on setting of service URL. The test for env file is not necessary, since in go-core slash stripped at later stage during request build.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
