### PR TITLE
Add missing semicolon in User-Agent header

### DIFF
--- a/common/cloudant_base.go
+++ b/common/cloudant_base.go
@@ -208,7 +208,7 @@ func buildUserAgent() string {
 
 // getSystemInfo returns the system information.
 func getSystemInfo() string {
-	return fmt.Sprintf("go.version=%s; os.name=%s os.arch=%s lang=go",
+	return fmt.Sprintf("go.version=%s; os.name=%s os.arch=%s lang=go;",
 		runtime.Version(),
 		runtime.GOOS,
 		runtime.GOARCH,


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->
Common User-Agent format across sdks should be `cloudant-<lang>-sdk/<sdk_version> (<lang>.version=<value>; [<lang>.vendor=<value>]; os.name=<value>; os.version=<value>; os.arch=<value>; lang=<lang>;)`

This PR adds trailing semicolon in sysinfo attributes list in User-Agent header.

Fixes: #251 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-go-sdk/blob/master/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
