### PR TITLE
docs: improve description of rev requirements for post/put document

### DIFF
--- a/examples/src/create_db_and_doc/create_db_and_doc.go
+++ b/examples/src/create_db_and_doc/create_db_and_doc.go
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2022. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,30 +52,48 @@ func main() {
 	}
 
 	// 3. Create a document ================================================
-	// 3.1. Create a document object with "example" id
+	// Create a document object with "example" id
 	exampleDocID := "example"
+	// Setting ID for the document is optional when "PostDocument" function
+	// is used for CREATE.
+	// When ID is not provided the server will generate one for your document.
 	exampleDocument := cloudantv1.Document{
 		ID: &exampleDocID,
 	}
 
-	// 3.2. Add "name" and "joined" fields to the document
+	// Add "name" and "joined" fields to the document
 	exampleDocument.SetProperty("name", "Bob Smith")
-	exampleDocument.SetProperty("joined", "2019-01-24T10:42:99.000Z")
+	exampleDocument.SetProperty("joined", "2019-01-24T10:42:59.000Z")
 
-	// 3.3. Save the document in the database
-	postDocumentOption := client.NewPostDocumentOptions(
+	// Save the document in the database with "PostDocument" function
+	createDocumentOptions := client.NewPostDocumentOptions(
 		exampleDbName,
 	).SetDocument(&exampleDocument)
 
-	postDocumentResult, _, err := client.PostDocument(postDocumentOption)
+	createDocumentResponse, _, err := client.PostDocument(createDocumentOptions)
+
+	// =====================================================================
+	// Note: saving the document can also be done with the "PutDocument"
+	// function. In this case docID is required for a CREATE operation:
+	/*
+		createDocumentOptions := client.NewPutDocumentOptions(
+			exampleDbName,
+			exampleDocID,
+		).SetDocument(&exampleDocument)
+
+		createDocumentResponse, _, err := client.PutDocument(createDocumentOptions)
+	*/
+	// =====================================================================
+
 	if err != nil {
 		panic(err)
 	}
 
-	// 3.4. Keep track of the revision number from the `example` document object
-	exampleDocument.Rev = postDocumentResult.Rev
+	// Keeping track of the revision number of the document object
+	// is necessary for further UPDATE/DELETE operations:
+	exampleDocument.Rev = createDocumentResponse.Rev
 
-	// 3.5. Print out the document content
+	// Print out the document content
 	exampleDocumentContent, _ := json.MarshalIndent(exampleDocument, "", "  ")
 	fmt.Printf("You have created the document:\n%s\n", string(exampleDocumentContent))
 }

--- a/examples/src/delete_doc/delete_doc.go
+++ b/examples/src/delete_doc/delete_doc.go
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2022. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,8 +58,8 @@ func main() {
 		deleteDocumentResult, _, err := client.DeleteDocument(
 			client.NewDeleteDocumentOptions(
 				exampleDbName,
-				*document.ID,
-			).SetRev(*document.Rev),
+				*document.ID, // docID is required for DELETE
+			).SetRev(*document.Rev), // Rev is required for DELETE
 		)
 		if err != nil {
 			panic(err)

--- a/examples/src/update_doc/update_doc.go
+++ b/examples/src/update_doc/update_doc.go
@@ -17,108 +17,109 @@
 package main
 
 import (
-  "encoding/json"
-  "fmt"
-  "github.com/IBM/cloudant-go-sdk/cloudantv1"
+	"encoding/json"
+	"fmt"
+
+	"github.com/IBM/cloudant-go-sdk/cloudantv1"
 )
 
 func main() {
-  // 1. Create a client with `CLOUDANT` default service name =============
-  client, err := cloudantv1.NewCloudantV1UsingExternalConfig(
-    &cloudantv1.CloudantV1Options{},
-  )
-  if err != nil {
-    panic(err)
-  }
+	// 1. Create a client with `CLOUDANT` default service name =============
+	client, err := cloudantv1.NewCloudantV1UsingExternalConfig(
+		&cloudantv1.CloudantV1Options{},
+	)
+	if err != nil {
+		panic(err)
+	}
 
-  // 2. Update the document ==============================================
-  exampleDbName := "orders"
-  exampleDocID := "example"
+	// 2. Update the document ==============================================
+	exampleDbName := "orders"
+	exampleDocID := "example"
 
-  // Get the document if it previously existed in the database
-  document, getDocumentResponse, err := client.GetDocument(
-    client.NewGetDocumentOptions(
-      exampleDbName,
-      exampleDocID,
-    ),
-  )
+	// Get the document if it previously existed in the database
+	document, getDocumentResponse, err := client.GetDocument(
+		client.NewGetDocumentOptions(
+			exampleDbName,
+			exampleDocID,
+		),
+	)
 
-  // =====================================================================
-  // Note: for response byte stream use:
-  /*
-  	documentAsByteStream, getDocumentResponse, err := client.GetDocumentAsStream(
-  		client.NewGetDocumentOptions(
-  			exampleDbName,
-  			exampleDocID,
-  		),
-  	)
-  */
-  // =====================================================================
+	// =====================================================================
+	// Note: for response byte stream use:
+	/*
+		documentAsByteStream, getDocumentResponse, err := client.GetDocumentAsStream(
+			client.NewGetDocumentOptions(
+				exampleDbName,
+				exampleDocID,
+			),
+		)
+	*/
+	// =====================================================================
 
-  if err != nil {
-    if getDocumentResponse.StatusCode == 404 {
-      fmt.Printf("Cannot update document because "+
-        "either \"%s\"  database or \"%s\" document was not found.\n",
-        exampleDbName,
-        exampleDocID)
-    } else {
-      panic(err)
-    }
-  }
+	if err != nil {
+		if getDocumentResponse.StatusCode == 404 {
+			fmt.Printf("Cannot update document because "+
+				"either \"%s\"  database or \"%s\" document was not found.\n",
+				exampleDbName,
+				exampleDocID)
+		} else {
+			panic(err)
+		}
+	}
 
-  if document != nil {
-    // Make some modification in the document content
-    // Add Bob Smith's address to the document
-    document.SetProperty("address", "19 Front Street, Darlington, DL5 1TY")
-    // Remove the joined property from document object
-    delete(document.GetProperties(), "joined")
+	if document != nil {
+		// Make some modification in the document content
+		// Add Bob Smith's address to the document
+		document.SetProperty("address", "19 Front Street, Darlington, DL5 1TY")
+		// Remove the joined property from document object
+		delete(document.GetProperties(), "joined")
 
-    // Update the document in the database
-    updateDocumentOptions := client.NewPostDocumentOptions(
-      exampleDbName,
-    ).SetDocument(document)
+		// Update the document in the database
+		updateDocumentOptions := client.NewPostDocumentOptions(
+			exampleDbName,
+		).SetDocument(document)
 
-    // =================================================================
-    // Note: for request byte stream use:
-    /*
-    	postDocumentOption := client.NewPostDocumentOptions(
-    		exampleDbName,
-    	).SetBody(documentAsByteStream)
-    */
-    // =================================================================
+		// =================================================================
+		// Note: for request byte stream use:
+		/*
+			postDocumentOption := client.NewPostDocumentOptions(
+				exampleDbName,
+			).SetBody(documentAsByteStream)
+		*/
+		// =================================================================
 
-    updateDocumentResponse, _, err := client.PostDocument(
-      updateDocumentOptions,
-    )
+		updateDocumentResponse, _, err := client.PostDocument(
+			updateDocumentOptions,
+		)
 
-    // =================================================================
-    // Note: updating the document can also be done with the "PutDocument"
-    // function. DocID and Rev are required for an UPDATE operation
-    // but Rev can be provided in the document object too:
-    /*
-    	updateDocumentOptions := client.NewPutDocumentOptions(
-    		exampleDbName,
-    		core.StringNilMapper(document.ID), // docID is a required parameter
-    	).SetDocument(document) // Rev in the document object CAN replace below SetRev
+		// =================================================================
+		// Note: updating the document can also be done with the "PutDocument"
+		// function. DocID and Rev are required for an UPDATE operation
+		// but Rev can be provided in the document object too:
+		/*
+			updateDocumentOptions := client.NewPutDocumentOptions(
+				exampleDbName,
+				core.StringNilMapper(document.ID), // docID is a required parameter
+			).SetDocument(document) // Rev in the document object CAN replace below SetRev
 
-    	updateDocumentOptions.SetRev(core.StringNilMapper(document.Rev))
+			updateDocumentOptions.SetRev(core.StringNilMapper(document.Rev))
 
-    	updateDocumentResponse, _, err := client.PutDocument(
-    		updateDocumentOptions,
-    	)
-    */
-    // =================================================================
+			updateDocumentResponse, _, err := client.PutDocument(
+				updateDocumentOptions,
+			)
+		*/
+		// =================================================================
 
-    if err != nil {
-      panic(err)
-    }
+		if err != nil {
+			panic(err)
+		}
 
-    // Keeping track of the latest revision number of the document object
-    // is necessary for further UPDATE/DELETE operations:
-    document.Rev = updateDocumentResponse.Rev
+		// Keeping track of the latest revision number of the document object
+		// is necessary for further UPDATE/DELETE operations:
+		document.Rev = updateDocumentResponse.Rev
 
-    // Print out the new document content
-    documentContent, _ := json.MarshalIndent(document, "", "  ")
-    fmt.Printf("You have updated the document:\n%s\n", string(documentContent))
-  }
+		// Print out the new document content
+		documentContent, _ := json.MarshalIndent(document, "", "  ")
+		fmt.Printf("You have updated the document:\n%s\n", string(documentContent))
+	}
 }

--- a/examples/src/update_doc/update_doc.go
+++ b/examples/src/update_doc/update_doc.go
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2022. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,81 +17,108 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/IBM/cloudant-go-sdk/cloudantv1"
+  "encoding/json"
+  "fmt"
+  "github.com/IBM/cloudant-go-sdk/cloudantv1"
 )
 
 func main() {
-	// 1. Create a client with `CLOUDANT` default service name =============
-	client, err := cloudantv1.NewCloudantV1UsingExternalConfig(
-		&cloudantv1.CloudantV1Options{},
-	)
-	if err != nil {
-		panic(err)
-	}
+  // 1. Create a client with `CLOUDANT` default service name =============
+  client, err := cloudantv1.NewCloudantV1UsingExternalConfig(
+    &cloudantv1.CloudantV1Options{},
+  )
+  if err != nil {
+    panic(err)
+  }
 
-	// 2. Update the document ==============================================
-	exampleDbName := "orders"
-	exampleDocID := "example"
+  // 2. Update the document ==============================================
+  exampleDbName := "orders"
+  exampleDocID := "example"
 
-	// 2.1. Get the document if it previously existed in the database
-	document, getDocumentResponse, err := client.GetDocument(
-		client.NewGetDocumentOptions(
-			exampleDbName,
-			exampleDocID,
-		),
-	)
+  // Get the document if it previously existed in the database
+  document, getDocumentResponse, err := client.GetDocument(
+    client.NewGetDocumentOptions(
+      exampleDbName,
+      exampleDocID,
+    ),
+  )
 
-	// Note: for response byte stream use:
-	// documentAsByteStream, getDocumentResponse, err := client.GetDocumentAsStream(
-	// 	client.NewGetDocumentOptions(
-	// 		exampleDbName,
-	// 		exampleDocID,
-	// 	),
-	// )
+  // =====================================================================
+  // Note: for response byte stream use:
+  /*
+  	documentAsByteStream, getDocumentResponse, err := client.GetDocumentAsStream(
+  		client.NewGetDocumentOptions(
+  			exampleDbName,
+  			exampleDocID,
+  		),
+  	)
+  */
+  // =====================================================================
 
-	if err != nil {
-		if getDocumentResponse.StatusCode == 404 {
-			fmt.Printf("Cannot update document because "+
-				"either \"%s\"  database or \"%s\" document was not found.\n",
-				exampleDbName,
-				exampleDocID)
-		} else {
-			panic(err)
-		}
-	}
+  if err != nil {
+    if getDocumentResponse.StatusCode == 404 {
+      fmt.Printf("Cannot update document because "+
+        "either \"%s\"  database or \"%s\" document was not found.\n",
+        exampleDbName,
+        exampleDocID)
+    } else {
+      panic(err)
+    }
+  }
 
-	if document != nil {
-		// 2.2. Make some modifiction in the document content
-		// 2.2.1. Add Bob Smith's address to the document
-		document.SetProperty("address", "19 Front Street, Darlington, DL5 1TY")
-		// 2.2.2. Remove the joined property from document object
-		delete(document.GetProperties(), "joined")
+  if document != nil {
+    // Make some modification in the document content
+    // Add Bob Smith's address to the document
+    document.SetProperty("address", "19 Front Street, Darlington, DL5 1TY")
+    // Remove the joined property from document object
+    delete(document.GetProperties(), "joined")
 
-		// 2.3. Update the document in the database
-		postDocumentOption := client.NewPostDocumentOptions(
-			exampleDbName,
-		).SetDocument(document)
+    // Update the document in the database
+    updateDocumentOptions := client.NewPostDocumentOptions(
+      exampleDbName,
+    ).SetDocument(document)
 
-		// Note: for request byte stream use:
-		// postDocumentOption := client.NewPostDocumentOptions(
-		// 	exampleDbName,
-		// ).SetBody(documentAsByteStream)
+    // =================================================================
+    // Note: for request byte stream use:
+    /*
+    	postDocumentOption := client.NewPostDocumentOptions(
+    		exampleDbName,
+    	).SetBody(documentAsByteStream)
+    */
+    // =================================================================
 
-		postDocumentResult, _, err := client.PostDocument(
-			postDocumentOption,
-		)
-		if err != nil {
-			panic(err)
-		}
+    updateDocumentResponse, _, err := client.PostDocument(
+      updateDocumentOptions,
+    )
 
-		// 2.4. Keep track the revision number of the document object
-		document.Rev = postDocumentResult.Rev
+    // =================================================================
+    // Note: updating the document can also be done with the "PutDocument"
+    // function. DocID and Rev are required for an UPDATE operation
+    // but Rev can be provided in the document object too:
+    /*
+    	updateDocumentOptions := client.NewPutDocumentOptions(
+    		exampleDbName,
+    		core.StringNilMapper(document.ID), // docID is a required parameter
+    	).SetDocument(document) // Rev in the document object CAN replace below SetRev
 
-		// 2.5. Print out the new document content
-		documentContent, _ := json.MarshalIndent(document, "", "  ")
-		fmt.Printf("You have updated the document:\n%s\n", string(documentContent))
-	}
+    	updateDocumentOptions.SetRev(core.StringNilMapper(document.Rev))
+
+    	updateDocumentResponse, _, err := client.PutDocument(
+    		updateDocumentOptions,
+    	)
+    */
+    // =================================================================
+
+    if err != nil {
+      panic(err)
+    }
+
+    // Keeping track of the latest revision number of the document object
+    // is necessary for further UPDATE/DELETE operations:
+    document.Rev = updateDocumentResponse.Rev
+
+    // Print out the new document content
+    documentContent, _ := json.MarshalIndent(document, "", "  ")
+    fmt.Printf("You have updated the document:\n%s\n", string(documentContent))
+  }
 }


### PR DESCRIPTION
## PR summary

The goal of this PR is to improve the description of `_rev`/`rev` requirements for post/put document. I also tried to explain where `_id`/`docId` is necessary similarly to `_rev`/`rev`.

I decided to use `/*...code is here...*/` for code comments and ornamentation lines before and after the explanation plus the commented out codes because with this way maybe the eyes can catch what belongs to what. Something like this:

```
// ========================================================================
// Note: the next code bla bla bla..:
/*
 code is here
*/
// ========================================================================
```

I removed sub-points in the examples, to align with the other examples in other libs.
I fixed the timestamp in the example to a valid format. 

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Lack of explanation around the usage of id and rev fields in CUD operation examples.

## What is the new behavior?
Explanation in example code how to use `putDocument` along with `postDocument` and:
* `_id` is a MUST at CREATE for `putDocument`
* `_id` is OPTIONAL at CREATE for `postDocument`
* `_id` is generated at CREATE when it is not provided `postDocument`
* `_id` and `_rev` is a MUST at UPDATE
*  `id` parameter is a MUST at UPDATE for `putDocument`
* `rev` parameter can be replaced by `_rev` in the document object both for `postDocument` and `putDocument`
* `id` and `rev` parameter is a MUST at DELETE 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
