### PR TITLE
fix: add missing operation names to path validator

### DIFF
--- a/common/cloudant_base.go
+++ b/common/cloudant_base.go
@@ -46,6 +46,9 @@ var docIdRule = validationRule{
 	operationIds: []string{
 		"DeleteDocument",
 		"GetDocument",
+		"GetDocumentAsMixed",
+		"GetDocumentAsRelated",
+		"GetDocumentAsStream",
 		"HeadDocument",
 		"PutDocument",
 		"DeleteAttachment",

--- a/common/cloudant_base_test.go
+++ b/common/cloudant_base_test.go
@@ -62,6 +62,40 @@ var _ = Describe(`Cloudant custom base service UT`, func() {
 		Expect(err.Error()).To(ContainSubstring("_testDocument"))
 	})
 
+	It("Validates a doc ID with GetDocumentAsStream", func() {
+		cloudant, err := NewBaseService(&core.ServiceOptions{
+			URL:           "https://cloudant.example",
+			Authenticator: &core.NoAuthAuthenticator{},
+		})
+		Expect(cloudant).ToNot(BeNil())
+		Expect(err).To(BeNil())
+
+		pathParamsMap := map[string]string{
+			"db":     "testDatabase",
+			"doc_id": "_testDocument",
+		}
+
+		builder := core.NewRequestBuilder(core.GET)
+		_, err = builder.ResolveRequestURL(cloudant.Options.URL, `/{db}/{doc_id}`, pathParamsMap)
+		if err != nil {
+			return
+		}
+
+		sdkHeaders := GetSdkHeaders("cloudant", "V1", "GetDocumentAsStream")
+		for headerName, headerValue := range sdkHeaders {
+			builder.AddHeader(headerName, headerValue)
+		}
+
+		request, err := builder.Build()
+		Expect(request).ToNot(BeNil())
+		Expect(err).To(BeNil())
+
+		response, err := cloudant.Request(request, nil)
+		Expect(response).To(BeNil())
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(ContainSubstring("_testDocument"))
+	})
+
 	It("Validates a doc ID at long service path", func() {
 		cloudant, err := NewBaseService(&core.ServiceOptions{
 			URL:           "https://cloudant.example/some/proxy/path",


### PR DESCRIPTION
## PR summary

add missing operation names to path validator

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Not all operations have paths validated

## What is the new behavior?
Validate paths additionally on

`getDocumentAsMixed`
`getDocumentAsRelated`
`getDocumentAsStream`

## Does this PR introduce a breaking change?

- [x] Yes - _only if previous users relied on previous behaviour_
- [ ] No

migration path: any applications which use special paths for the above operations should use the correct operation, eg one of the `*AllDocs*` methods in the case of the `_all_docs` path.

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
