### PR TITLE
Refactor session auth to use cookie jar and share base service http client

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "stubs/.+\\.json|go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-08-02T15:30:29Z",
+  "generated_at": "2023-08-11T16:56:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -102,7 +102,7 @@
         "hashed_secret": "12dea96fec20593566ab75692c9949596833adc9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 40,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -110,15 +110,7 @@
         "hashed_secret": "39eecf6dda11fe10e41163ecf9f25decd0f5d63e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 68,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ea06f40359c76421f72f13801cd78110c36c3d93",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 308,
+        "line_number": 71,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/auth/session.go
+++ b/auth/session.go
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2023. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,12 +52,9 @@ func (s *session) getCookie() *http.Cookie {
 	return s.cookie
 }
 
-// isValid checks if session has the cookie and it hasn't expired yet
+// isValid checks if the auth cookie hasn't expired yet
 func (s *session) isValid() bool {
-	if s.cookie != nil && time.Now().Before(s.expires) {
-		return true
-	}
-	return false
+	return time.Now().Before(s.expires)
 }
 
 // needsRefresh atomically identifies if the cookie is near of the expiration time

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2023. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,10 +90,6 @@ var _ = Describe("Session Unit Tests", func() {
 		Expect(s.isValid()).To(BeTrue())
 
 		s.expires = time.Now().Add(-time.Minute)
-		Expect(s.isValid()).ToNot(BeTrue())
-
-		s.expires = time.Now().Add(time.Hour)
-		s.cookie = nil
 		Expect(s.isValid()).ToNot(BeTrue())
 	})
 

--- a/common/cloudant_base_test.go
+++ b/common/cloudant_base_test.go
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2021, 2022. All Rights Reserved.
+ * © Copyright IBM Corporation 2021, 2023. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,12 @@ package common
 import (
 	"net/http"
 	"net/http/cookiejar"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path"
 	"runtime"
+	"time"
 
 	"github.com/IBM/cloudant-go-sdk/auth"
 	"github.com/IBM/go-sdk-core/v5/core"
@@ -169,43 +171,6 @@ var _ = Describe(`Cloudant custom base service UT`, func() {
 		Expect(err.Error()).To(ContainSubstring("_testDocument"))
 	})
 
-	It("Create new Authenticator from environment", func() {
-		pwd, err := os.Getwd()
-		Expect(err).To(BeNil())
-		credentialFilePath := path.Join(pwd, "/testdata/my-credentials.env")
-		os.Setenv("IBM_CREDENTIALS_FILE", credentialFilePath)
-
-		authenticator, err := GetAuthenticatorFromEnvironment("service1")
-		Expect(err).To(BeNil())
-		Expect(authenticator).ToNot(BeNil())
-		Expect(authenticator.AuthenticationType()).To(Equal(auth.AUTHTYPE_COUCHDB_SESSION))
-
-		sessionAuth, ok := authenticator.(*auth.CouchDbSessionAuthenticator)
-		Expect(ok).To(BeTrue())
-		Expect(sessionAuth.URL).ToNot(BeZero())
-		Expect(sessionAuth.DisableSSLVerification).To(BeFalse())
-
-		authenticator, err = GetAuthenticatorFromEnvironment("service2")
-		Expect(err).To(BeNil())
-		Expect(authenticator).ToNot(BeNil())
-		Expect(authenticator.AuthenticationType()).To(Equal(auth.AUTHTYPE_COUCHDB_SESSION))
-
-		sessionAuth, ok = authenticator.(*auth.CouchDbSessionAuthenticator)
-		Expect(ok).To(BeTrue())
-		Expect(sessionAuth.URL).ToNot(BeZero())
-		Expect(sessionAuth.DisableSSLVerification).To(BeTrue())
-
-		authenticator, err = GetAuthenticatorFromEnvironment("service3")
-		Expect(err).To(BeNil())
-		Expect(authenticator).ToNot(BeNil())
-		Expect(authenticator.AuthenticationType()).To(Equal(core.AUTHTYPE_IAM))
-
-		authenticator, err = GetAuthenticatorFromEnvironment("service4")
-		Expect(err).To(BeNil())
-		Expect(authenticator).ToNot(BeNil())
-		Expect(authenticator.AuthenticationType()).To(Equal(core.AUTHTYPE_IAM))
-	})
-
 	It("Validates URL trailing slash is stripped", func() {
 		cloudant, err := NewBaseService(&core.ServiceOptions{
 			URL:           "https://cloudant.example/",
@@ -236,55 +201,187 @@ var _ = Describe(`Cloudant custom base service UT`, func() {
 		Expect(cloudant.UserAgent).To(ContainSubstring(runtime.GOARCH))
 	})
 
-	It("Validates cookie jar enabled for all auths", func() {
-		couchDbAuth, err := GetAuthenticatorFromEnvironment("service1")
-		Expect(err).To(BeNil())
-		iamAuth, err := GetAuthenticatorFromEnvironment("service3")
-		Expect(err).To(BeNil())
-		basicAuth, err := GetAuthenticatorFromEnvironment("service5")
-		Expect(err).To(BeNil())
-		authList := []core.Authenticator{
-			&core.NoAuthAuthenticator{},
-			couchDbAuth,
-			iamAuth,
-			basicAuth,
-		}
-		for _, item := range authList {
+	Context("with IBM_CREDENTIALS env variable", func() {
+		BeforeEach(func() {
+			pwd, err := os.Getwd()
+			Expect(err).To(BeNil())
+			credentialFilePath := path.Join(pwd, "/testdata/my-credentials.env")
+			err = os.Setenv("IBM_CREDENTIALS_FILE", credentialFilePath)
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			err := os.Unsetenv("IBM_CREDENTIALS_FILE")
+			Expect(err).To(BeNil())
+		})
+
+		It("Create new Authenticator from environment", func() {
+			authenticator, err := GetAuthenticatorFromEnvironment("service1")
+			Expect(err).To(BeNil())
+			Expect(authenticator).ToNot(BeNil())
+			Expect(authenticator.AuthenticationType()).To(Equal(auth.AUTHTYPE_COUCHDB_SESSION))
+
+			sessionAuth, ok := authenticator.(*auth.CouchDbSessionAuthenticator)
+			Expect(ok).To(BeTrue())
+			Expect(sessionAuth.URL).ToNot(BeZero())
+			Expect(sessionAuth.DisableSSLVerification).To(BeFalse())
+
+			authenticator, err = GetAuthenticatorFromEnvironment("service2")
+			Expect(err).To(BeNil())
+			Expect(authenticator).ToNot(BeNil())
+			Expect(authenticator.AuthenticationType()).To(Equal(auth.AUTHTYPE_COUCHDB_SESSION))
+
+			sessionAuth, ok = authenticator.(*auth.CouchDbSessionAuthenticator)
+			Expect(ok).To(BeTrue())
+			Expect(sessionAuth.URL).ToNot(BeZero())
+			Expect(sessionAuth.DisableSSLVerification).To(BeTrue())
+
+			authenticator, err = GetAuthenticatorFromEnvironment("service3")
+			Expect(err).To(BeNil())
+			Expect(authenticator).ToNot(BeNil())
+			Expect(authenticator.AuthenticationType()).To(Equal(core.AUTHTYPE_IAM))
+
+			authenticator, err = GetAuthenticatorFromEnvironment("service4")
+			Expect(err).To(BeNil())
+			Expect(authenticator).ToNot(BeNil())
+			Expect(authenticator.AuthenticationType()).To(Equal(core.AUTHTYPE_IAM))
+		})
+
+		It("Validates cookie jar enabled for all auths", func() {
+			couchDbAuth, err := GetAuthenticatorFromEnvironment("service1")
+			Expect(err).To(BeNil())
+			iamAuth, err := GetAuthenticatorFromEnvironment("service3")
+			Expect(err).To(BeNil())
+			basicAuth, err := GetAuthenticatorFromEnvironment("service5")
+			Expect(err).To(BeNil())
+			authList := []core.Authenticator{
+				&core.NoAuthAuthenticator{},
+				couchDbAuth,
+				iamAuth,
+				basicAuth,
+			}
+			for _, item := range authList {
+				cloudant, err := NewBaseService(&core.ServiceOptions{
+					URL:           "https://cloudant.example",
+					Authenticator: item,
+				})
+				Expect(cloudant).ToNot(BeNil())
+				Expect(err).To(BeNil())
+				Expect(cloudant.BaseService.Client.Jar).ToNot(BeNil())
+
+				// set custom client
+				client := &http.Client{Timeout: time.Second}
+				cloudant.SetHTTPClient(client)
+				Expect(cloudant.BaseService.Client.Jar).ToNot(BeNil())
+				Expect(cloudant.BaseService.Client.Timeout).To(Equal(time.Second))
+			}
+		})
+
+		It("Validates custom cookie jar", func() {
+			client := core.DefaultHTTPClient()
+
+			jar, err := cookiejar.New(nil)
+			Expect(err).To(BeNil())
+			// create cookie for custom jar
+			urlObj, _ := url.Parse("http://localhost:8080/")
+			cookie := &http.Cookie{
+				Name:  "token",
+				Value: "some_token",
+			}
+			jar.SetCookies(urlObj, []*http.Cookie{cookie})
+			client.Jar = jar
+
+			iamAuth, err := GetAuthenticatorFromEnvironment("service3")
+			Expect(err).To(BeNil())
 			cloudant, err := NewBaseService(&core.ServiceOptions{
 				URL:           "https://cloudant.example",
-				Authenticator: item,
+				Authenticator: iamAuth,
 			})
+			cloudant.SetHTTPClient(client)
+
 			Expect(cloudant).ToNot(BeNil())
 			Expect(err).To(BeNil())
 			Expect(cloudant.BaseService.Client.Jar).ToNot(BeNil())
-		}
-	})
-
-	It("Validates custom cookie jar", func() {
-		client := core.DefaultHTTPClient()
-
-		jar, err := cookiejar.New(nil)
-		Expect(err).To(BeNil())
-		// create cookie for custom jar
-		urlObj, _ := url.Parse("http://localhost:8080/")
-		cookie := &http.Cookie{
-			Name:  "token",
-			Value: "some_token",
-		}
-		jar.SetCookies(urlObj, []*http.Cookie{cookie})
-		client.Jar = jar
-
-		iamAuth, err := GetAuthenticatorFromEnvironment("service3")
-		Expect(err).To(BeNil())
-		cloudant, err := NewBaseService(&core.ServiceOptions{
-			URL:           "https://cloudant.example",
-			Authenticator: iamAuth,
+			Expect(cloudant.BaseService.Client.Jar.Cookies(urlObj)[0]).Should(Equal(cookie))
 		})
-		cloudant.BaseService.SetHTTPClient(client)
 
-		Expect(cloudant).ToNot(BeNil())
-		Expect(err).To(BeNil())
-		Expect(cloudant.BaseService.Client.Jar).ToNot(BeNil())
-		Expect(cloudant.BaseService.Client.Jar.Cookies(urlObj)[0]).Should(Equal(cookie))
+		It("Validates cookie jar used for CouchDB Session auths", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/_session":
+					if _, err := r.Cookie("AuthSession"); err != nil {
+						http.SetCookie(w, &http.Cookie{
+							Name:  "AuthSession",
+							Value: "fakefake",
+						})
+					}
+					w.WriteHeader(http.StatusOK)
+				case "/db":
+					w.WriteHeader(http.StatusOK)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			auth, err := GetAuthenticatorFromEnvironment("service1")
+			Expect(err).To(BeNil())
+			Expect(auth).ToNot(BeNil())
+
+			cloudant, err := NewBaseService(&core.ServiceOptions{
+				URL:           server.URL,
+				Authenticator: auth,
+			})
+			Expect(err).To(BeNil())
+			Expect(cloudant).ToNot(BeNil())
+			Expect(cloudant.BaseService.Client.Jar).ToNot(BeNil())
+
+			builder := core.NewRequestBuilder(core.GET)
+			_, err = builder.ResolveRequestURL(server.URL, "/db", nil)
+			Expect(err).To(BeNil())
+			sdkHeaders := GetSdkHeaders("cloudant", "V1", "GetDatabase")
+			for headerName, headerValue := range sdkHeaders {
+				builder.AddHeader(headerName, headerValue)
+			}
+
+			request, err := builder.Build()
+			Expect(request).ToNot(BeNil())
+			Expect(err).To(BeNil())
+
+			_, err = cloudant.Request(request, nil)
+			Expect(err).To(BeNil())
+
+			u, err := url.Parse(server.URL)
+			Expect(err).To(BeNil())
+			var cookie *http.Cookie
+			for _, c := range cloudant.BaseService.Client.Jar.Cookies(u) {
+				if c.Name == "AuthSession" {
+					cookie = c
+					break
+				}
+			}
+			Expect(cookie).ToNot(BeNil())
+			Expect(cookie.Value).To(Equal("fakefake"))
+		})
+
+		It("Validates SetHTTPClient passes URL to CouchDB Session auth", func() {
+			a, err := auth.NewCouchDbSessionAuthenticator("foo", "bar")
+			Expect(err).To(BeNil())
+			Expect(a.URL).To(Equal(""))
+
+			cloudant, err := NewBaseService(&core.ServiceOptions{
+				URL:           "https://localhost:8080",
+				Authenticator: a,
+			})
+			Expect(cloudant).ToNot(BeNil())
+			Expect(err).To(BeNil())
+
+			newUrl := "https://cloudant.example:5984"
+			err = cloudant.SetServiceURL(newUrl)
+			Expect(err).To(BeNil())
+
+			Expect(cloudant.BaseService.GetServiceURL()).To(Equal(newUrl))
+			Expect(a.URL).To(Equal(newUrl))
+		})
 	})
 })

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.27.10
+	golang.org/x/net v0.12.0
 )
 
 require (
@@ -25,7 +26,6 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
-	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect


### PR DESCRIPTION
## PR summary

This refactoring makes CouchDB Session authenticator to use cookiejar to store authsession cookie and set it to requests and makes `BaseService` to set its HTTP client as client for CouchDB Session authenticator to share its cookiejar.

This is motivated by changes in CouchDB where server now sets auth session cookie on basic auth.

<!-- please include a brief summary of the changes in this PR -->

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
