### PR TITLE
fix: race in session auth's cookie refresh

### DIFF
--- a/auth/couchdb_session_authenticator_test.go
+++ b/auth/couchdb_session_authenticator_test.go
@@ -351,11 +351,9 @@ func getCookie(a *CouchDbSessionAuthenticator) (*http.Cookie, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := a.refreshCookie(); err != nil {
-		return nil, err
-	}
+	cookie, err := a.refreshCookie()
 	if a.client.Jar == nil && a.session != nil {
-		return a.session.getCookie(), nil
+		return cookie, err
 	}
 	for _, cookie := range a.client.Jar.Cookies(url) {
 		if cookie.Name == "AuthSession" {


### PR DESCRIPTION
## PR summary

A race was introduced in #399 where a cookie read for clients with no cookiejar set was happening outside of the read lock. This PR makes sure we are reading cookie in the same thread that refreshes it.

Fixes: #406 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-go-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
