### PR TITLE
fix(test): safe parsing of string into int32 in tests fixtures

### DIFF
--- a/features/changes_follower_test_fixtures.go
+++ b/features/changes_follower_test_fixtures.go
@@ -238,7 +238,7 @@ func (ms *MockServer) Start() *cloudantv1.CloudantV1 {
 				return
 			}
 
-			l, err := strconv.Atoi(r.URL.Query().Get("limit"))
+			l, err := strconv.ParseUint(r.URL.Query().Get("limit"), 10, 32)
 			Expect(err).ShouldNot(HaveOccurred())
 			ms.limit.Store(int32(l))
 		}


### PR DESCRIPTION
## PR summary

Safer parsing of string representing limit into `int32` in follower's text fixtures, that's mindful of upper bound.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Query string parsed with `strconv.Atoi`

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Query string pared with `strconv.ParseUint` with `bitSize` explicitly set to 32

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
