### PR TITLE
fix(ci): skip package cache on golangci-lint action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,5 @@ jobs:
       run: go test ./... -coverprofile=coverage.txt -covermode=count
     - name: Run lint
       uses: golangci/golangci-lint-action@v3
+      with:
+        skip-pkg-cache: true


### PR DESCRIPTION
## PR summary

While running `golangci/golangci-lint-action@v3` in CI we are getting number of warnings about "File exists" which is a known issue with `golangci-lint` and related to use of cache.

It seems that this prevents of actual linting beyond of the first version in lang matrix even though the tests are passing green. Disabling the cache seems to be a recommended workaround.

Fixes: #445 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-go-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
