### PR TITLE
fix: supression of context errors in changes follower's runner

### DIFF
--- a/features/changes_follower.go
+++ b/features/changes_follower.go
@@ -357,7 +357,7 @@ func (cf *ChangesFollower) run(m Mode) (<-chan ChangesItem, error) {
 	go func() {
 		defer close(changes)
 		for batch := range cf.getChangesBatch() {
-			if batch.error != nil && (errors.Is(cf.ctx.Err(), context.Canceled) || errors.Is(cf.ctx.Err(), context.DeadlineExceeded)) {
+			if errors.Is(cf.ctx.Err(), context.Canceled) || errors.Is(cf.ctx.Err(), context.DeadlineExceeded) {
 				return
 			} else if batch.error != nil {
 				select {

--- a/features/changes_follower.go
+++ b/features/changes_follower.go
@@ -357,7 +357,7 @@ func (cf *ChangesFollower) run(m Mode) (<-chan ChangesItem, error) {
 	go func() {
 		defer close(changes)
 		for batch := range cf.getChangesBatch() {
-			if errors.Is(batch.error, context.Canceled) || errors.Is(batch.error, context.DeadlineExceeded) {
+			if batch.error != nil && (errors.Is(cf.ctx.Err(), context.Canceled) || errors.Is(cf.ctx.Err(), context.DeadlineExceeded)) {
 				return
 			} else if batch.error != nil {
 				select {


### PR DESCRIPTION
## PR summary

In the latest release `github.com/IBM/go-sdk-core/v5/core` added a wrapper around returned errors and that broke our error suppression for context related errors in changes follower. This PR restores that functionality. 

Fixes: #467 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-go-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
