### PR TITLE
fix: return an error on reading ChangesItem from a closed channel

### DIFF
--- a/features/changes_follower.go
+++ b/features/changes_follower.go
@@ -149,6 +149,10 @@ type ChangesItem struct {
 // that either returns an acquired item or an error received
 // during its fetch.
 func (ci ChangesItem) Item() (cloudantv1.ChangesResultItem, error) {
+	if ci.error == nil && ci.item.ID == nil {
+		err := core.SDKErrorf(nil, "can't read from a closed channel", "changes-follower-closed-channel", common.GetComponentInfo())
+		return ci.item, err
+	}
 	return ci.item, ci.error
 }
 

--- a/features/changes_follower_test.go
+++ b/features/changes_follower_test.go
@@ -1123,7 +1123,9 @@ var _ = Describe(`ChangesFollower with context`, func() {
 		ci := <-changesCh
 		Expect(changesCh).Should(BeClosed())
 		item, err := ci.Item()
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(Equal("can't read from a closed channel"))
+		Expect(errors.As(err, &expectedErrType)).To(BeTrue())
 		Expect(item).To(Equal(cloudantv1.ChangesResultItem{}))
 	})
 })


### PR DESCRIPTION
## PR summary

In changes follower it is possible to read from a closed changes channel and get an empty `ChangesItem` as a result. This is expected behaviour in golang by itself, but we have a method `Item()` on `ChangesItem` and calling it on an empty `ChangesItem` returns no error and empty `cloudantv1.ChangesResultItem` which can be confusing.

This PR changes this behaviour and returns an error "can't read from a closed channel" instead, based on assumption that there are no other way to actual get an empty `ChangesItem` from changes channel.

Fixes: #471 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-go-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
