### PR TITLE
ci: set GOTOOLCHAIN to local

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: docs
 on:
   pull_request:
     branches: ['main']
+env:
+  GOTOOLCHAIN: local
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches-ignore: ['gh-pages']
 env:
+  GOTOOLCHAIN: local
   WIREMOCK_URL: http://127.0.0.1:8080
   WIREMOCK_PORT: 8080
 jobs:

--- a/auth/couchdb_session_authenticator.go
+++ b/auth/couchdb_session_authenticator.go
@@ -222,7 +222,7 @@ func (a *CouchDbSessionAuthenticator) requestSession() (*session, error) {
 			Headers:    resp.Header,
 			RawResult:  buff.Bytes(),
 		}
-		err := fmt.Errorf(buff.String())
+		err := fmt.Errorf("%s", buff)
 
 		cInfo := common.GetComponentInfo()
 		component := core.NewProblemComponent(cInfo.Name, cInfo.Version)


### PR DESCRIPTION
## PR summary

Set GOTOOLCHAIN to local in Github Actions to ensure that we are testing with expected go version.

Update:

Also a fix for a new linter error for new rule added in a latest version of `golangci-lint`

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
