### PR TITLE
Update go versions to the range of 1.22, 1.23

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,11 +12,11 @@ jobs:
       uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - name: Install Go 1.21
+    - name: Install Go 1.22
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
-        check-latest: false
+        go-version: '1.22'
+        check-latest: true
         cache: true
     - name: Build docs
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ['1.21', '1.22']
+        go: ['1.22', '1.23']
     runs-on: ubuntu-latest
     services:
       wiremock:
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
-        check-latest: false
+        check-latest: true
         cache: true
     - name: Setup Wiremock
       shell: bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/cloudant-go-sdk
 
-go 1.21.12
+go 1.22
 
 require (
 	github.com/IBM/go-sdk-core/v5 v5.17.5


### PR DESCRIPTION
## PR summary

* Update GHA workflow matrix to include 1.23 and remove 1.21.
* Latest two major releases of Go are supported. This PR drops 1.21 and adds 1.22.7 as minimum version in `go.mod`.
https://tip.golang.org/doc/devel/release#policy

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
