### PR TITLE
feat: set x-request-id as error trace

### DIFF
--- a/base/cloudant_base_test.go
+++ b/base/cloudant_base_test.go
@@ -586,6 +586,43 @@ var _ = Describe(`Cloudant custom base service UT`, func() {
 				}`,
 			},
 			{
+				description: "Validates augmented error with reason and request id",
+				status:      http.StatusTeapot,
+				headers: map[string]string{
+					"x-request-id": "test_req_id",
+					"content-type": "application/json",
+				},
+				body: errorReasonBody,
+				expect: `{
+					"trace": "test_req_id",
+					"error": "test_value",
+					"reason": "A valid test reason",
+					"errors": [{
+						"code": "test_value",
+						"message": "test_value: A valid test reason"
+					}]
+				}`,
+			},
+			{
+				description: "Validates augmented error with reason and preferred request id",
+				status:      http.StatusTeapot,
+				headers: map[string]string{
+					"x-request-id":       "preferred_req_id",
+					"x-couch-request-id": "test_req_id",
+					"content-type":       "application/json",
+				},
+				body: errorReasonBody,
+				expect: `{
+					"trace": "preferred_req_id",
+					"error": "test_value",
+					"reason": "A valid test reason",
+					"errors": [{
+						"code": "test_value",
+						"message": "test_value: A valid test reason"
+					}]
+				}`,
+			},
+			{
 				description: "Validates augmented error with reason and trace as a stream",
 				status:      http.StatusTeapot,
 				headers:     defaultHeaders,

--- a/base/error_response_transport.go
+++ b/base/error_response_transport.go
@@ -110,7 +110,10 @@ func transformError(resp *http.Response) error {
 		}
 	}
 
-	trace := resp.Header.Get("X-Couch-Request-Id")
+	trace := resp.Header.Get("X-Request-Id")
+	if trace == "" {
+		trace = resp.Header.Get("X-Couch-Request-Id")
+	}
 	if _, ok := respError["errors"]; ok && trace != "" {
 		respError["trace"] = trace
 		respErrorWasAugmented = true


### PR DESCRIPTION
## PR summary

If the x-request-id header is on a response use it to set the error trace field (in preference to x-couch-request-id, but still use x-couch-request-id if there is no x-request-id).

Fixes: part of s1037

**Note: An existing issue is [required](https://github.com/IBM/cloudant-go-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
