### PR TITLE
fix: add modifications on ranges and counts for SearchResult and SearchResultProperties

### DIFF
--- a/cloudantv1/cloudant_v1.go
+++ b/cloudantv1/cloudant_v1.go
@@ -19710,12 +19710,12 @@ func UnmarshalSearchResult(m map[string]json.RawMessage, result interface{}) (er
 		err = core.SDKErrorf(err, "", "by-error", common.GetComponentInfo())
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "counts", &obj.Counts)
+	err = base.UnmarshalPrimitiveSpecial(m, "counts", &obj.Counts, reflect.TypeOf(obj).String())
 	if err != nil {
 		err = core.SDKErrorf(err, "", "counts-error", common.GetComponentInfo())
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "ranges", &obj.Ranges)
+	err = base.UnmarshalPrimitiveSpecial(m, "ranges", &obj.Ranges, reflect.TypeOf(obj).String())
 	if err != nil {
 		err = core.SDKErrorf(err, "", "ranges-error", common.GetComponentInfo())
 		return
@@ -19774,12 +19774,12 @@ func UnmarshalSearchResultProperties(m map[string]json.RawMessage, result interf
 		err = core.SDKErrorf(err, "", "by-error", common.GetComponentInfo())
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "counts", &obj.Counts)
+	err = base.UnmarshalPrimitiveSpecial(m, "counts", &obj.Counts, reflect.TypeOf(obj).String())
 	if err != nil {
 		err = core.SDKErrorf(err, "", "counts-error", common.GetComponentInfo())
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "ranges", &obj.Ranges)
+	err = base.UnmarshalPrimitiveSpecial(m, "ranges", &obj.Ranges, reflect.TypeOf(obj).String())
 	if err != nil {
 		err = core.SDKErrorf(err, "", "ranges-error", common.GetComponentInfo())
 		return


### PR DESCRIPTION
## PR summary

Fixes: s1043

**Note: An existing issue is [required](https://github.com/IBM/cloudant-go-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?

The SDK cannot unmarshal whole float numbers as `4.0` as `int64` for `ranges` and `counts` of the `SearchResult` and `SearchResultProperties` objects and fails with unmarshal error.

## What is the new behavior?

An interim layer unmarshals numbers to `float64`, then marshals it to a byte array that can be unmarshalled to `int64` without any failures.

Unmarshalling fractions is still not supported.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
