### PR TITLE
refactor(follower): use normal feed for one-off changes

### DIFF
--- a/features/changes_follower.go
+++ b/features/changes_follower.go
@@ -296,8 +296,13 @@ func validateOptions(o *cloudantv1.PostChangesOptions) error {
 }
 
 func (cf *ChangesFollower) setOptionsDefaults() *ChangesFollower {
-	cf.options.SetFeed(cloudantv1.PostChangesOptionsFeedLongpollConst)
-	cf.options.SetTimeout(LongpollTimeout.Milliseconds())
+	switch cf.mode {
+	case Finite:
+		cf.options.SetFeed(cloudantv1.PostChangesOptionsFeedNormalConst)
+	case Listen:
+		cf.options.SetFeed(cloudantv1.PostChangesOptionsFeedLongpollConst)
+		cf.options.SetTimeout(LongpollTimeout.Milliseconds())
+	}
 	return cf
 }
 

--- a/features/changes_follower_test.go
+++ b/features/changes_follower_test.go
@@ -192,8 +192,15 @@ var _ = Describe(`ChangesFollower options`, func() {
 
 			Expect(followerErr).ShouldNot(HaveOccurred())
 			Expect(follower).ToNot(BeNil())
+			Expect(follower.mode).To(Equal(Finite))
+			Expect(follower.options).ToNot(BeNil())
 
 			o := follower.options
+			Expect(*o.Feed).Should(Equal(cloudantv1.PostChangesOptionsFeedNormalConst))
+
+			follower.mode = Listen
+			follower.setOptionsDefaults()
+
 			Expect(*o.Feed).Should(Equal(cloudantv1.PostChangesOptionsFeedLongpollConst))
 			Expect(*o.Timeout).Should(Equal(LongpollTimeout.Milliseconds()))
 		})
@@ -203,13 +210,20 @@ var _ = Describe(`ChangesFollower options`, func() {
 
 			Expect(followerErr).ShouldNot(HaveOccurred())
 			Expect(follower).ToNot(BeNil())
+			Expect(follower.mode).To(Equal(Finite))
+			Expect(follower.options).ToNot(BeNil())
 
 			follower.setOptionsDefaults().withLimit(12)
 
 			o := follower.options
+			Expect(*o.Feed).Should(Equal(cloudantv1.PostChangesOptionsFeedNormalConst))
+
+			follower.mode = Listen
+			follower.setOptionsDefaults().withLimit(12)
+
 			Expect(*o.Feed).Should(Equal(cloudantv1.PostChangesOptionsFeedLongpollConst))
 			Expect(*o.Timeout).Should(Equal(LongpollTimeout.Milliseconds()))
-			Expect(*o.Limit).Should(Equal(int64(12)))
+			Expect(*o.Limit).Should(BeEquivalentTo(12))
 		})
 
 		It(`Set defaults with PostChangesOptions limit`, func() {
@@ -218,13 +232,20 @@ var _ = Describe(`ChangesFollower options`, func() {
 
 			Expect(followerErr).ShouldNot(HaveOccurred())
 			Expect(follower).ToNot(BeNil())
+			Expect(follower.mode).To(Equal(Finite))
+			Expect(follower.options).ToNot(BeNil())
 
 			follower.setOptionsDefaults().withLimit(12)
 
 			o := follower.options
+			Expect(*o.Feed).Should(Equal(cloudantv1.PostChangesOptionsFeedNormalConst))
+
+			follower.mode = Listen
+			follower.setOptionsDefaults().withLimit(12)
+
 			Expect(*o.Feed).Should(Equal(cloudantv1.PostChangesOptionsFeedLongpollConst))
 			Expect(*o.Timeout).Should(Equal(LongpollTimeout.Milliseconds()))
-			Expect(*o.Limit).Should(Equal(int64(12)))
+			Expect(*o.Limit).Should(BeEquivalentTo(12))
 		})
 	})
 


### PR DESCRIPTION
## PR summary

Use normal feed mode for changes follower one-off FINITE mode.

Fixes: s1115 / i445

**Note: An existing issue is [required](https://github.com/IBM/cloudant-go-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe) - performance improvement

## What is the current behavior?

Currently the changes follower uses `longpoll` feed type is for both start (`LISTEN`) and `startOneOff` (`FINITE`) cases.

## What is the new behavior?

Switch to use the `normal` feed type for `startOneOff` (`FINITE`) mode to avoid waiting unnecessarily till timeout on empty feeds.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information
